### PR TITLE
feat-#17: Basic score functionality

### DIFF
--- a/game/kegeland/App.tsx
+++ b/game/kegeland/App.tsx
@@ -29,6 +29,7 @@ const App = () => {
             initialRouteName="Home"
             screenOptions={{
               headerShown: false,
+              gestureEnabled: false,
             }}
           >
             <Stack.Screen name="Home" component={HomeScreen} />

--- a/game/kegeland/physics.ts
+++ b/game/kegeland/physics.ts
@@ -33,7 +33,16 @@ const Physics = (
     Matter.Body.setPosition(entities['Obstacle'].body, pipeSizePos.pipe.pos);
   };
 
+  if (
+    entities['Obstacle'].body.bounds.max.x <= 10 &&
+    !entities['Obstacle'].point
+  ) {
+    entities['Obstacle'].point = true;
+    dispatch({ type: 'new_point' });
+  }
+
   if (entities['Obstacle'].body.bounds.max.x <= 0) {
+    entities['Obstacle'].point = false;
     moveObstacle();
   }
 

--- a/game/kegeland/src/screens/Game/GameScreen.tsx
+++ b/game/kegeland/src/screens/Game/GameScreen.tsx
@@ -9,6 +9,7 @@ import { NavigationScreenProps } from '../navigation.types';
 const GameScreen = ({ navigation }: NavigationScreenProps) => {
   const handleGameOver = () => navigation.navigate('GameOver');
   const [lives, setLives] = useState(3);
+  const [points, setPoints] = useState(0);
   useEffect(() => {
     if (lives === 0) handleGameOver();
   }, [lives]);
@@ -17,12 +18,21 @@ const GameScreen = ({ navigation }: NavigationScreenProps) => {
       <Text
         style={{
           textAlign: 'center',
-          fontSize: 40,
+          fontSize: 25,
           fontWeight: 'bold',
-          margin: 20,
+          margin: 10,
         }}
       >
         Lives: {lives}
+      </Text>
+      <Text
+        style={{
+          textAlign: 'center',
+          fontSize: 25,
+          fontWeight: 'bold',
+        }}
+      >
+        Points: {points}
       </Text>
       <GameEngine
         entities={entities()}
@@ -32,6 +42,10 @@ const GameScreen = ({ navigation }: NavigationScreenProps) => {
           switch (e.type) {
             case 'hit_obstacle':
               setLives(lives - 1);
+              break;
+            case 'new_point':
+              setPoints(points + 1);
+              break;
           }
         }}
       ></GameEngine>


### PR DESCRIPTION
One point is added for each obstacle passed. If the player hits an obstacle they do not get a point. Also disabled swipe to go back to prevent going back to the game after losing.
Closes #17 
![20210920_144301000_iOS](https://user-images.githubusercontent.com/44811386/134022284-30b838d6-921d-470e-b8ff-e13a4f99f0c9.png)
