### PR TITLE
feat-#74: Change input from tapping to holding

### DIFF
--- a/game/kegeland/components/Bounds.tsx
+++ b/game/kegeland/components/Bounds.tsx
@@ -1,11 +1,7 @@
 import { World, Bodies } from 'matter-js';
 import React from 'react';
 import { View } from 'react-native';
-import { Dimensions } from 'react-native';
 import { IEntity, IHitbox } from './components.types';
-
-const windowHeight = Dimensions.get('window').height;
-const windowWidth = Dimensions.get('window').width;
 
 const Bounds = (props: IEntity) => {
   // Size of boundary calculated from the hitbox

--- a/game/kegeland/physics.ts
+++ b/game/kegeland/physics.ts
@@ -15,16 +15,26 @@ const Physics = (
   { touches, time, dispatch }: GameEngineUpdateEventOptionType
 ) => {
   let engine = entities.physics.engine;
-  let yVelocity: number;
   touches
-    .filter((t: TouchEvent) => t.type === 'press')
+    .filter((t: TouchEvent) => t.type === 'start')
     .forEach((t: TouchEvent) => {
-      yVelocity = t.event.pageY < windowHeight / 2 ? -4 : 4;
-      Matter.Body.setVelocity(entities.Player.body, {
-        x: 0,
-        y: yVelocity,
-      });
+      if (t.event.pageY < windowHeight / 2) {
+        entities.Player.speed = -4;
+      } else {
+        entities.Player.speed = 4;
+      }
     });
+  touches
+    .filter((t: TouchEvent) => t.type === 'end')
+    .forEach((t: TouchEvent) => {
+      entities.Player.speed = 0;
+    });
+  if (entities.Player.speed < 0 || entities.Player.speed > 0) {
+    Matter.Body.setVelocity(entities.Player.body, {
+      x: 0,
+      y: entities.Player.speed,
+    });
+  }
 
   Matter.Engine.update(engine, time.delta);
 


### PR DESCRIPTION
Change control for going up or down from tapping to press and hold. There is no press and hold action in react native game engine, so this is done by detecting start and stop of a press. On the start of a press the speed is set so that it will be applied every loop iteration until the end of the press, when it is set to 0. Also removed some unused code.
Closes #74 