### PR TITLE
fix-#116: Fix bug that crashes the game

### DIFF
--- a/game/kegeland/components/Obstacle.tsx
+++ b/game/kegeland/components/Obstacle.tsx
@@ -1,7 +1,7 @@
 import { World, Bodies } from 'matter-js';
 import React from 'react';
 import { View } from 'react-native';
-import { IEntity, IHitboxObstacle } from './components.types';
+import { IEntity, IHitboxMoveable } from './components.types';
 
 const Obstacle = (props: IEntity) => {
   // Size of obstacle calculated from the hitbox
@@ -30,7 +30,7 @@ const Obstacle = (props: IEntity) => {
   );
 };
 
-export default ({ world, pos, size, speed }: IHitboxObstacle) => {
+export default ({ world, pos, size, speed }: IHitboxMoveable) => {
   const obstacle = Bodies.rectangle(pos.x, pos.y, size.width, size.height, {
     label: 'Obstacle',
     isStatic: true,

--- a/game/kegeland/components/Player.tsx
+++ b/game/kegeland/components/Player.tsx
@@ -1,7 +1,7 @@
 import { World, Bodies } from 'matter-js';
 import React from 'react';
 import { Image } from 'react-native';
-import { IEntity, IHitbox } from './components.types';
+import { IEntity, IHitbox, IHitboxMoveable } from './components.types';
 import PlaneImage from '../assets/plane_1_pink.png';
 import FishImage from '../assets/fish.png';
 import PhysicsOne from '../physics/physicsOne';
@@ -39,7 +39,7 @@ const Player = (props: IEntity) => {
   );
 };
 
-export default ({ world, pos, size }: IHitbox) => {
+export default ({ world, pos, size, speed }: IHitboxMoveable) => {
   const player = Bodies.rectangle(pos.x, pos.y, size.width, size.height, {
     label: 'Player',
   });
@@ -53,6 +53,7 @@ export default ({ world, pos, size }: IHitbox) => {
   return {
     body: player,
     pos,
+    speed,
     renderer: <Player body={player} />,
   };
 };

--- a/game/kegeland/components/components.types.ts
+++ b/game/kegeland/components/components.types.ts
@@ -18,6 +18,6 @@ export interface IHitbox {
   size: ISize;
 }
 
-export interface IHitboxObstacle extends IHitbox {
+export interface IHitboxMoveable extends IHitbox {
   speed: number;
 }

--- a/game/kegeland/entities/index.tsx
+++ b/game/kegeland/entities/index.tsx
@@ -31,6 +31,7 @@ const Entities = () => {
       world,
       pos: { x: 50, y: playerY },
       size: { width: 75, height: 50 },
+      speed: 0,
     }),
     Floor: Bounds({
       world,


### PR DESCRIPTION
Fixes the bug that crashes the game when the user hits an obstacle before touching the screen. The solution was to set the speed of the player initially so that it is not null.
Closes #116 