### PR TITLE
chore-#118: Disable animation between screens

### DIFF
--- a/game/kegeland/App.tsx
+++ b/game/kegeland/App.tsx
@@ -36,6 +36,7 @@ const App = () => {
             screenOptions={{
               headerShown: false,
               gestureEnabled: false,
+              animation: 'none',
             }}
           >
             <Stack.Screen name="Home" component={HomeScreen} />


### PR DESCRIPTION
Disables animation between screens, because it looks like the user are going back when taking questionnaires multiple times.
Close #118 