### PR TITLE
bug: Fix shield being active if the user dies while active

### DIFF
--- a/game/kegeland/state-management/game/gameSlice.ts
+++ b/game/kegeland/state-management/game/gameSlice.ts
@@ -74,6 +74,7 @@ export const gameSlice = createSlice({
       state.gameId = '';
       state.lives = 3;
       state.running = true;
+      state.shieldActive = false;
 
       switch (action.payload) {
         case GameMode.OneControl:


### PR DESCRIPTION
Set the shieldActive to false on clearGame to avoid this bug